### PR TITLE
React 0.30 update; Cross-platform Linking, Android support, Promises

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react-native"]
+}

--- a/AppLinkNavigation.js
+++ b/AppLinkNavigation.js
@@ -11,8 +11,8 @@
  */
 'use strict';
 
-var React = require('react-native');
-var { LinkingIOS } = React;
+var React = require('react');
+var { Linking, Platform } = require('react-native');
 var AppLinkURL = require('./AppLinkURL');
 
 var USER_AGENT = 'react-native-applinks 0.0.1';
@@ -30,11 +30,12 @@ class AppLinkNavigation {
   ) {
     this._appLinkResolver = app_link_resolver;
     this._refererAppLink = referer_app_link;
-    this._platform = platform || 'ios';
+    this._platform = platform || Platform.OS;
     switch (this._platform) {
       case 'iphone':
       case 'ipad':
       case 'ios':
+      case 'android':
         break;
       default:
         throw 'Unexpected platform: ' + platform;
@@ -54,12 +55,16 @@ class AppLinkNavigation {
       error('Empty applink object.');
     }
 
-    var targets = al.getTargets('ios');
+    var targets;
 
     if (this._platform === 'iphone') {
+      targets = al.getTargets('ios');
       targets = al.getTargets('iphone').concat(targets);
     } else if (this._platform === 'ipad') {
+      targets = al.getTargets('ios');
       targets = al.getTargets('ipad').concat(targets);
+    } else {
+      targets = al.getTargets(this._platform);
     }
 
     this._findBestTarget(targets, 0,
@@ -80,7 +85,7 @@ class AppLinkNavigation {
     if (index >= targets.length) {
       onNotFound();
     } else {
-      LinkingIOS.canOpenURL(targets[index].url, (supported) => {
+      Linking.canOpenURL(targets[index].url, (supported) => {
         if (supported) {
           onFound(targets[index]);
         } else {

--- a/AppLinkResolver.js
+++ b/AppLinkResolver.js
@@ -14,8 +14,8 @@
 var URL = require('url');
 
 class AppLinkResolver {
-  resolve(web_url: String, success, error) {
-    throw 'Not implemented';
+  resolve(web_url: String): Promise<any> {
+    return Promise.reject(new Error('Not implemented'));
   }
 
   normalizeUrl(url: String): String {

--- a/IndexAPIAppLinkResolver.js
+++ b/IndexAPIAppLinkResolver.js
@@ -20,7 +20,7 @@ class IndexAPIAppLinkResolver extends AppLinkResolver {
     this._facebookToken = facebook_token;
   }
 
-  resolve(web_url, success, error) {
+  resolve(web_url) {
     var webUrl = super.normalizeUrl(web_url);
 
     if (!this._facebookToken) {
@@ -35,13 +35,10 @@ class IndexAPIAppLinkResolver extends AppLinkResolver {
       + encodeURIComponent(this._facebookToken);
     indexAPIEndpoint = super.normalizeUrl(indexAPIEndpoint);
 
-    fetch(indexAPIEndpoint)
+    return fetch(indexAPIEndpoint)
       .then(res => res.json())
       .then((json) => {
-        success(new AppLink(webUrl, json[webUrl].app_links));
-      })
-      .catch(function(err) {
-        error(err);
+        return new AppLink(webUrl, json[webUrl].app_links);
       });
   }
 }

--- a/NativeAppLinkResolver.js
+++ b/NativeAppLinkResolver.js
@@ -17,17 +17,14 @@ var parse5 = require('parse5');
 var AppLink = require('./AppLink');
 
 class NativeAppLinkResolver extends AppLinkResolver {
-  resolve(web_url: string, success: Function, error: Function) {
+  resolve(web_url: string) {
     var webUrl = super.normalizeUrl(web_url);
 
-    fetch(webUrl, {method: 'get', headers: {'Prefer-Html-Meta-Tags': 'al'}})
+    return fetch(webUrl, {method: 'get', headers: {'Prefer-Html-Meta-Tags': 'al'}})
       .then(res => res.text())
       .then((body) => {
         var appLinkHost = NativeAppLinkResolver.parseHTML(body);
-        success(new AppLink(webUrl, appLinkHost));
-      })
-      .catch(function(err) {
-        error(err);
+        return new AppLink(webUrl, appLinkHost);
       });
   }
 

--- a/NativeAppLinkResolver.js
+++ b/NativeAppLinkResolver.js
@@ -13,7 +13,7 @@
 
 var AppLinkResolver = require('./AppLinkResolver');
 
-var parse5 = require('parse5');
+var Parser = require('parse5/lib/parser');
 var AppLink = require('./AppLink');
 
 class NativeAppLinkResolver extends AppLinkResolver {
@@ -33,7 +33,8 @@ class NativeAppLinkResolver extends AppLinkResolver {
    * Learn App Links meta tags schema at http://applinks.org/
    */
   static parseHTML(html_str: String) {
-    var dom = parse5.parse(html_str);
+    var parser = new Parser();
+    var dom = parser.parse(html_str);
     var html = dom.childNodes.filter(n => n.tagName === 'html')[0];
     var head = html.childNodes.filter(n => n.tagName === 'head')[0];
     var metaTags = head.childNodes.filter(t => t.tagName === 'meta');

--- a/NativeAppLinkResolver.js
+++ b/NativeAppLinkResolver.js
@@ -13,7 +13,7 @@
 
 var AppLinkResolver = require('./AppLinkResolver');
 
-var Parser = require('parse5').Parser;
+var parse5 = require('parse5');
 var AppLink = require('./AppLink');
 
 class NativeAppLinkResolver extends AppLinkResolver {
@@ -36,8 +36,7 @@ class NativeAppLinkResolver extends AppLinkResolver {
    * Learn App Links meta tags schema at http://applinks.org/
    */
   static parseHTML(html_str: String) {
-    var parser = new Parser();
-    var dom = parser.parse(html_str);
+    var dom = parse5.parse(html_str);
     var html = dom.childNodes.filter(n => n.tagName === 'html')[0];
     var head = html.childNodes.filter(n => n.tagName === 'head')[0];
     var metaTags = head.childNodes.filter(t => t.tagName === 'meta');

--- a/__tests__/main-test.js
+++ b/__tests__/main-test.js
@@ -8,13 +8,6 @@
  */
 'use strict';
 
-jest
-  .dontMock('parse5')
-  .dontMock('url')
-  .dontMock('../AppLinkURL')
-  .dontMock('../NativeAppLinkResolver')
-  .dontMock('../AppLink');
-
 var AppLink = require('../AppLink');
 var NativeAppLinkResolver = require('../NativeAppLinkResolver');
 var AppLinkURL = require('../AppLinkURL');

--- a/__tests__/navigation-test.js
+++ b/__tests__/navigation-test.js
@@ -17,11 +17,11 @@ var Linking = require('Linking');
  * Mocking Linking calls
  */
 Linking.canOpenURL = jest.genMockFunction()
-  .mockImplementation(function(url, supported) {
-  console.log('Mock call Linking.canOpenURL:' + url);
-  var isSupported = url.indexOf('_v1') >= 0;
-  supported(isSupported);
-});
+  .mockImplementation(function(url) {
+    console.log('Mock call Linking.canOpenURL:' + url);
+    var isSupported = url.indexOf('_v1') >= 0;
+    return Promise.resolve(isSupported);
+  });
 
 describe('App Links Navigation', function() {
   it('Targets priorities test', function() {
@@ -42,30 +42,20 @@ describe('App Links Navigation', function() {
       }
     );
 
-    alNavigationIOS.fetchUrlFromAppLink(
-      al,
-      (url) => { expect(url).toContain('ios_v1') }
-    );
+    alNavigationIOS.fetchUrlFromAppLink(al)
+      .then((url) => { expect(url).toContain('ios_v1') });
 
-    alNavigationIPhone.fetchUrlFromAppLink(
-      al,
-      (url) => { expect(url).toContain('iphone_v1') }
-    );
+    alNavigationIPhone.fetchUrlFromAppLink(al)
+      .then((url) => { expect(url).toContain('iphone_v1') });
 
-    alNavigationIPad.fetchUrlFromAppLink(
-      al,
-      (url) => { expect(url).toContain('ipad_v1') }
-    );
+    alNavigationIPad.fetchUrlFromAppLink(al)
+      .then((url) => { expect(url).toContain('ipad_v1') });
 
-    alNavigationAndroid.fetchUrlFromAppLink(
-      al,
-      (url) => { expect(url).toContain('android_v1') }
-    );
+    alNavigationAndroid.fetchUrlFromAppLink(al)
+      .then((url) => { expect(url).toContain('android_v1') });
 
-    alNavigationDefault.fetchUrlFromAppLink(
-      al,
-      (url) => { expect(url).toContain('ios_v1') }
-    );
+    alNavigationDefault.fetchUrlFromAppLink(al)
+      .then((url) => { expect(url).toContain('ios_v1') });
   });
 
   it('Wrong platform test', function() {

--- a/__tests__/navigation-test.js
+++ b/__tests__/navigation-test.js
@@ -8,14 +8,6 @@
  */
 'use strict';
 
-jest
-  .dontMock('parse5')
-  .dontMock('url')
-  .dontMock('../AppLinkURL')
-  .dontMock('../NativeAppLinkResolver')
-  .dontMock('../AppLink')
-  .dontMock('../AppLinkNavigation');
-
 var AppLink = require('../AppLink');
 var AppLinkNavigation = require('../AppLinkNavigation');
 var AppLinkResolver = require('../AppLinkResolver');

--- a/__tests__/navigation-test.js
+++ b/__tests__/navigation-test.js
@@ -11,14 +11,14 @@
 var AppLink = require('../AppLink');
 var AppLinkNavigation = require('../AppLinkNavigation');
 var AppLinkResolver = require('../AppLinkResolver');
-var LinkingIOS = require('LinkingIOS');
+var Linking = require('Linking');
 
 /**
- * Mocking LinkingIOS calls
+ * Mocking Linking calls
  */
-LinkingIOS.canOpenURL = jest.genMockFunction()
+Linking.canOpenURL = jest.genMockFunction()
   .mockImplementation(function(url, supported) {
-  console.log('Mock call LinkingIOS.canOpenURL:' + url);
+  console.log('Mock call Linking.canOpenURL:' + url);
   var isSupported = url.indexOf('_v1') >= 0;
   supported(isSupported);
 });
@@ -29,6 +29,7 @@ describe('App Links Navigation', function() {
     var alNavigationIOS = new AppLinkNavigation(resolver, null, 'ios');
     var alNavigationIPhone = new AppLinkNavigation(resolver, null, 'iphone');
     var alNavigationIPad = new AppLinkNavigation(resolver, null, 'ipad');
+    var alNavigationAndroid = new AppLinkNavigation(resolver, null, 'android');
     var alNavigationDefault = new AppLinkNavigation(resolver);
 
     var al = new AppLink(
@@ -36,7 +37,8 @@ describe('App Links Navigation', function() {
       {
         ios: [{url: 'ios_v2://home'}, {url: 'ios_v1://home'}],
         iphone: [{url: 'iphone_v2://home'}, {url: 'iphone_v1://home'}],
-        ipad: [{url: 'ipad_v2://home'}, {url: 'ipad_v1://home'}]
+        ipad: [{url: 'ipad_v2://home'}, {url: 'ipad_v1://home'}],
+        android: [{url: 'android_v2://home'}, {url: 'android_v1://home'}]
       }
     );
 
@@ -53,6 +55,11 @@ describe('App Links Navigation', function() {
     alNavigationIPad.fetchUrlFromAppLink(
       al,
       (url) => { expect(url).toContain('ipad_v1') }
+    );
+
+    alNavigationAndroid.fetchUrlFromAppLink(
+      al,
+      (url) => { expect(url).toContain('android_v1') }
     );
 
     alNavigationDefault.fetchUrlFromAppLink(

--- a/package.json
+++ b/package.json
@@ -8,18 +8,27 @@
     "email": "nov@facebook.com",
     "url": "http://github.com/knovikov"
   },
+  "repository": "facebook/react-native-applinks",
   "scripts": {
     "test": "jest"
   },
+  "jest": {
+    "preset": "jest-react-native"
+  },
   "devDependencies": {
-    "jest": "~0.1.5"
+    "babel-jest": "^15.0.0",
+    "babel-preset-react-native": "^1.9.0",
+    "jest": "^15.1.1",
+    "jest-react-native": "^15.0.0",
+    "react": "^15.3.1",
+    "react-native": ">=0.30.0"
   },
   "dependencies": {
-    "parse5": "~1.4.2",
-    "url": "~0.10.3"
+    "parse5": "^2.2.1",
+    "url": "^0.11.0"
   },
   "peerDependencies": {
-    "react-native": ">=0.17.0"
+    "react-native": ">=0.30.0"
   },
   "homepage": "http://github.com/facebook/react-native-applinks/",
   "keywords": [
@@ -27,6 +36,6 @@
     "applinks",
     "react native",
     "react native applinks"
-   ],
-  "license": "BSD License"
+  ],
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
This branch does the following:
- Updates to react-native 0.30+
- Replaces the deprecated `LinkerIOS` with the new cross-platform `Linker` and handles the api changes
- Adds support for android, now that the linker is cross-platform
- Switches to a Promise based API to match the Linker's change to a Promise based API
- Fixes some bugs in `package.json` causing errors or warnings (missing repository, invalid license value, peer deps not included in dev deps for testing)
